### PR TITLE
Refactor out _exact_predict

### DIFF
--- a/gpytorch/__init__.py
+++ b/gpytorch/__init__.py
@@ -1,24 +1,13 @@
 import torch
 from torch.autograd import Variable
 from .lazy import LazyVariable, ToeplitzLazyVariable
-from .random_variables import GaussianRandomVariable
 from .module import Module
 from .gp_model import GPModel
 from .functions import AddDiag, DSMM, ExactGPMarginalLogLikelihood, \
     NormalCDF, LogNormalCDF, TraceLogDetQuadForm
-from .utils import LinearCG, function_factory
-from .utils.toeplitz import index_coef_to_sparse, interpolated_sym_toeplitz_mul, sym_toeplitz_mv
-
-
-__all__ = [
-    ToeplitzLazyVariable,
-    Module,
-    GPModel,
-    AddDiag,
-    ExactGPMarginalLogLikelihood,
-    NormalCDF,
-    LogNormalCDF,
-]
+from .utils import function_factory
+from .random_variables import GaussianRandomVariable
+from .utils.toeplitz import index_coef_to_sparse
 
 
 _invmm_class = function_factory.invmm_factory()
@@ -46,6 +35,13 @@ def add_diag(input, diag):
         return AddDiag()(input, diag)
 
 
+def add_jitter(covar):
+    if isinstance(covar, LazyVariable):
+        covar.add_jitter_()
+    else:
+        covar.data.add_(1e-3 * torch.eye(len(covar)))
+
+
 def dsmm(sparse_mat, dense_mat):
     return DSMM(sparse_mat)(dense_mat)
 
@@ -64,7 +60,7 @@ def exact_gp_marginal_log_likelihood(covar, target):
         - scalar - The marginal log likelihood of the data.
     """
     if isinstance(covar, LazyVariable):
-        return covar.gp_marginal_log_likelihood(target)
+        return covar.exact_gp_marginal_log_likelihood(target)
     else:
         return ExactGPMarginalLogLikelihood()(covar, target)
 
@@ -101,13 +97,6 @@ def invmv(mat, vec):
     return res.view(-1)
 
 
-def normal_cdf(x):
-    """
-    Computes the element-wise standard normal CDF of an input tensor x.
-    """
-    return NormalCDF()(x)
-
-
 def log_normal_cdf(x):
     """
     Computes the element-wise log standard normal CDF of an input tensor x.
@@ -116,6 +105,24 @@ def log_normal_cdf(x):
     manually, as it is more numerically stable.
     """
     return LogNormalCDF()(x)
+
+
+def monte_carlo_log_likelihood(log_probability_func, train_y,
+                               variational_mean, chol_var_covar,
+                               train_covar, num_samples):
+    if isinstance(train_covar, LazyVariable):
+        log_likelihood = train_covar.monte_carlo_log_likelihood(log_probability_func,
+                                                                train_y,
+                                                                variational_mean,
+                                                                chol_var_covar,
+                                                                num_samples)
+    else:
+        epsilon = Variable(torch.randn(len(train_covar), num_samples))
+        samples = chol_var_covar.t().mm(epsilon)
+        samples = samples + variational_mean.unsqueeze(1)
+        log_likelihood = log_probability_func(samples, train_y)
+
+    return log_likelihood
 
 
 def mvn_kl_divergence(mean_1, chol_covar_1, mean_2, covar_2, num_samples=10):
@@ -156,96 +163,70 @@ def mvn_kl_divergence(mean_1, chol_covar_1, mean_2, covar_2, num_samples=10):
     return res
 
 
-def add_jitter(covar):
-    if isinstance(covar, LazyVariable):
-        covar.add_jitter_()
-    else:
-        covar.data.add_(1e-3 * torch.eye(len(covar)))
-
-
-def monte_carlo_log_likelihood(log_probability_func, train_y,
-                               variational_mean, chol_var_covar,
-                               train_covar, num_samples):
-    if isinstance(train_covar, LazyVariable):
-        log_likelihood = train_covar.monte_carlo_log_likelihood(log_probability_func,
-                                                                train_y,
-                                                                variational_mean,
-                                                                chol_var_covar,
-                                                                num_samples)
-    else:
-        epsilon = Variable(torch.randn(len(train_covar), num_samples))
-        samples = chol_var_covar.t().mm(epsilon)
-        samples = samples + variational_mean.unsqueeze(1)
-        log_likelihood = log_probability_func(samples, train_y)
-
-    return log_likelihood
-
-
-def _exact_predict(test_mean, test_test_covar, train_y, train_mean,
-                   train_train_covar, train_test_covar, test_train_covar, alpha=None):
+def normal_cdf(x):
     """
-    Computes the predictive mean and variance of a posterior Gaussian process. Additionally computes
-    certain posterior parameters that can be cached between rounds of predictions.
-
-        Args:
-            - test_mean (vector k) - prior mean values for the test points.
-            - test_test_covar (matrix kxk) - prior covariance matrix for the test points.
-            - train_y (vector n) - training labels
-            - train_mean (vector n) - prior mean values for the training points
-            - train_train_covar (matrix nxn) - Variable or LazyVariable representing the train-train covariance matrix.
-                                               Usually takes the form (K+sI), where K is the prior covariance matrix and
-                                               s is the noise variance.
-            - train_test_covar (matrix nxk) - prior covariance matrix between training and test points.
-            - test_train_covar (matrix nxk) - prior covariance matrix between test and training points.
-                                              Usually, this is simply the transpose of train_test_covar.
-            - alpha (vector n) - Coefficients for predictive mean that do not depend on the test points.
-                                 If not supplied, this function will compute them.
-
-        Returns:
-            - GaussianRandomVariable with the predictive mean and covariance matrix for the test points.
-            - alpha (vector n) - Coefficients that can be reused when this function is next called.
+    Computes the element-wise standard normal CDF of an input tensor x.
     """
-    if isinstance(train_train_covar, ToeplitzLazyVariable):
-        W_test_left = index_coef_to_sparse(test_train_covar.J_left,
-                                           test_train_covar.C_left,
-                                           len(test_train_covar.c))
-        W_train_left = index_coef_to_sparse(train_train_covar.J_left,
-                                            train_train_covar.C_left,
-                                            len(train_train_covar.c))
-        W_train_right = index_coef_to_sparse(train_train_covar.J_right,
-                                             train_train_covar.C_right,
-                                             len(train_train_covar.c))
-        noise_diag = train_train_covar.added_diag
+    return NormalCDF()(x)
 
-        def train_mul_closure(v):
-            return interpolated_sym_toeplitz_mul(train_train_covar.c.data, v,
-                                                 W_train_left, W_train_right, noise_diag.data)
 
-        # Update test mean
-        if alpha is None:
-            alpha = LinearCG().solve(train_mul_closure, train_y - train_mean.data).unsqueeze(1)
-            alpha = torch.dsmm(W_train_right.t(), alpha).squeeze()
-            alpha = sym_toeplitz_mv(train_train_covar.c.data, alpha).unsqueeze(1)
+def exact_posterior_alpha(train_train_covar, train_mean, train_y):
+    """
+    Returns alpha - a vector to memoize for calculating the
+    mean of the posterior GP on test points
 
-        test_mean = Variable(test_mean.data.add(torch.dsmm(W_test_left, alpha).squeeze()))
+    Args:
+        - train_train_covar ((Lazy)Variable nxn) - prior covariance matrix between
+                                                   test and training points.
+        - train_mean (Variable n) - prior mean values for the test points.
+        - train_y (Variable n) - alpha vector, computed from exact_posterior_alpha
+    """
+    if isinstance(train_train_covar, LazyVariable):
+        return train_train_covar.exact_posterior_alpha(train_mean, train_y)
+    return invmv(train_train_covar, train_y - train_mean)
 
-        # TODO: Add a diagonal only mode / use implicit math
+
+def exact_posterior_mean(test_train_covar, test_mean, alpha):
+    """
+    Returns the mean of the posterior GP on test points, given
+    prior means/covars
+
+    Args:
+        - test_train_covar ((Lazy)Variable nxm) - prior covariance matrix between
+                                                  test and training points.
+        - test_mean (Variable m) - prior mean values for the test points.
+        - alpha (Variable m) - alpha vector, computed from exact_posterior_alpha
+    """
+    if isinstance(test_train_covar, LazyVariable):
+        return test_train_covar.exact_posterior_mean(test_mean, alpha)
+    return test_mean.add(torch.mv(test_train_covar, alpha))
+
+
+def exact_posterior_covar(test_test_covar, test_train_covar, train_test_covar, train_train_covar):
+    """
+    Returns the covar of the posterior GP on test points, given
+    prior means/covars
+
+    Args:
+        - test_test_covar ((Lazy)Variable nxm) - prior covariance matrix between test and training points.
+                                                 Usually, this is simply the transpose of train_test_covar.
+        - test_train_covar ((Lazy)Variable nxm) - prior covariance matrix between test and training points.
+                                                  Usually, this is simply the transpose of train_test_covar.
+        - train_test_covar ((Lazy)Variable nxm) - prior covariance matrix between training and test points.
+        - train_train_covar ((Lazy)Variable nxn) - train-train covariance matrix.
+                                                   Usually takes the form (K+sI), where K is the prior
+                                                   covariance matrix and s is the noise variance.
+    """
+    # TODO: Add a diagonal only mode / use implicit math
+    if isinstance(train_test_covar, LazyVariable):
         train_test_covar = train_test_covar.evaluate()
+    if isinstance(test_train_covar, LazyVariable):
         test_train_covar = train_test_covar.t()
+    if isinstance(test_test_covar, LazyVariable):
         test_test_covar = test_test_covar.evaluate()
 
-    else:
-        train_y_var = Variable(train_y)
-        if alpha is None:
-            alpha = invmv(train_train_covar, train_y_var - train_mean)
-
-        test_mean = test_mean.add(torch.mv(test_train_covar, alpha))
-
-    # Update test-test covar
-    test_test_covar_correction = test_train_covar.mm(invmm(train_train_covar, train_test_covar))
-    test_test_covar = test_test_covar.sub(test_test_covar_correction)
-
-    return GaussianRandomVariable(test_mean, test_test_covar), alpha
+    test_test_covar_correction = torch.mm(test_train_covar, invmm(train_train_covar, train_test_covar))
+    return test_test_covar.sub(test_test_covar_correction)
 
 
 def _variational_predict(n, full_covar, variational_mean, chol_variational_covar, alpha=None):
@@ -290,3 +271,23 @@ def _variational_predict(n, full_covar, variational_mean, chol_variational_covar
         f_posterior = GaussianRandomVariable(test_mean, test_covar)
 
     return f_posterior, alpha
+
+
+__all__ = [
+    ToeplitzLazyVariable,
+    Module,
+    GPModel,
+    add_diag,
+    add_jitter,
+    dsmm,
+    exact_gp_marginal_log_likelihood,
+    invmm,
+    invmv,
+    log_normal_cdf,
+    monte_carlo_log_likelihood,
+    mvn_kl_divergence,
+    normal_cdf,
+    exact_posterior_alpha,
+    exact_posterior_mean,
+    exact_posterior_covar,
+]

--- a/gpytorch/lazy/lazy_variable.py
+++ b/gpytorch/lazy/lazy_variable.py
@@ -1,22 +1,25 @@
 class LazyVariable(object):
+    def add_diag(self, diag):
+        """
+        Adds an element to the diagonal of the matrix.
+
+        Args:
+            - diag (Scalar Variable)
+        """
+        raise NotImplementedError
+
+    def add_jitter_(self):
+        """
+        Adds jitter (i.e., a small diagonal component) to the matrix this LazyVariable represents.
+        This could potentially be implemented as a no-op, however this could lead to numerical instabilities,
+        so this should only be done at the user's risk.
+        """
+
     def evaluate(self):
         """
         Explicitly evaluates the matrix this LazyVariable represents. This
         function should return a Variable explicitly wrapping a Tensor storing
         an exact representation of this LazyVariable.
-        """
-        raise NotImplementedError
-
-    def add_diag(self, diag):
-        """
-        Adds a diagonal component to this lazy variable in a potentially lazy fashion.
-        That is, if this lazy variable represents some matrix A, add_diag should return
-        a LazyVariable of the same type that represents A+dI.
-
-        Args:
-            - diag (scalar) - diagonal component to add.
-        Returns:
-            - LazyVariable representing this current LazyVariable plus diag*I.
         """
         raise NotImplementedError
 
@@ -29,22 +32,6 @@ class LazyVariable(object):
             - target (vector n) - training label vector to be used in the marginal log likelihood calculation.
         Returns:
             - scalar - The GP marginal log likelihood where (K+\sigma^{2}I) is represented by this LazyVariable.
-        """
-        raise NotImplementedError
-
-    def mvn_kl_divergence(self, mean_1, chol_covar_1, mean_2):
-        """
-        Computes the KL divergence between two multivariate Normal distributions. The first of these
-        distributions is specified by mean_1 and chol_covar_1, while the second distribution is specified
-        by mean_2 and this LazyVariable.
-
-        Args:
-            - mean_1 (vector n) - Mean vector of the first Gaussian distribution.
-            - chol_covar_1 (matrix n x n) - Cholesky factorization of the covariance matrix of the first Gaussian
-                                            distribution.
-            - mean_2 (vector n) - Mean vector of the second Gaussian distribution.
-        Returns:
-            - KL divergence between N(mean_1, chol_covar_1) and N(mean_2, self)
         """
         raise NotImplementedError
 
@@ -66,10 +53,46 @@ class LazyVariable(object):
         """
         raise NotImplementedError
 
-    def add_jitter_(self):
+    def mvn_kl_divergence(self, mean_1, chol_covar_1, mean_2):
         """
-        Adds jitter (i.e., a small diagonal component) to the matrix this LazyVariable represents.
-        This could potentially be implemented as a no-op, however this could lead to numerical instabilities,
-        so this should only be done at the user's risk.
+        Computes the KL divergence between two multivariate Normal distributions. The first of these
+        distributions is specified by mean_1 and chol_covar_1, while the second distribution is specified
+        by mean_2 and this LazyVariable.
+
+        Args:
+            - mean_1 (vector n) - Mean vector of the first Gaussian distribution.
+            - chol_covar_1 (matrix n x n) - Cholesky factorization of the covariance matrix of the first Gaussian
+                                            distribution.
+            - mean_2 (vector n) - Mean vector of the second Gaussian distribution.
+        Returns:
+            - KL divergence between N(mean_1, chol_covar_1) and N(mean_2, self)
         """
+        raise NotImplementedError
+
+    def exact_posterior_alpha(self, train_mean, train_y):
+        """
+        Assumes that self represents the train-train prior covariance matrix.
+
+        Returns alpha - a vector to memoize for calculating the
+        mean of the posterior GP on test points
+
+        Args:
+            - train_mean (Variable n) - prior mean values for the test points.
+            - train_y (Variable n) - alpha vector, computed from exact_posterior_alpha
+        """
+
+    def exact_posterior_mean(self, test_mean, alpha):
+        """
+        Assumes that self represents the test-train prior covariance matrix.
+
+        Returns the mean of the posterior GP on test points, given
+        prior means/covars
+
+        Args:
+            - test_mean (Variable m) - prior mean values for the test points.
+            - alpha (Variable m) - alpha vector, computed from exact_posterior_alpha
+        """
+        raise NotImplementedError
+
+    def __getitem__(self, index):
         raise NotImplementedError


### PR DESCRIPTION
This adds 3 methods to `gpytorch/__init__.py` and LazyVariables:
  - `posterior_alpha` - create a cache for the mean
  - `posterior_mean` - calculates the mean (given the alpha cache)
  - `posterior_covar` - calculates the covariance

With this in place, we can remove `_exact_predict` from `gpytorch/__init__.py`, and the logic for `forward` in `ExactGPPosterior` is super simple.

I plan on doing the same thing for the variational case as well.

cc/ @jrg365 @wrh14