### PR TITLE
Simpler Initialization  for Spectral Mixture Kernel

### DIFF
--- a/gpytorch/kernels/spectral_mixture_kernel.py
+++ b/gpytorch/kernels/spectral_mixture_kernel.py
@@ -2,18 +2,39 @@ import math
 import torch
 from torch import nn
 from .kernel import Kernel
+from torch.autograd import Variable
+import gpytorch.utils.fft as fft
 
 
 class SpectralMixtureKernel(Kernel):
     def __init__(self, n_mixtures, log_mixture_weight_bounds=(-100, 100),
                  log_mixture_mean_bounds=(-100, 100), log_mixture_scale_bounds=(-100, 100)):
         super(SpectralMixtureKernel, self).__init__()
+        self.n_mixtures = n_mixtures
         self.register_parameter('log_mixture_weights', nn.Parameter(torch.zeros(n_mixtures)),
                                 bounds=log_mixture_weight_bounds)
         self.register_parameter('log_mixture_means', nn.Parameter(torch.zeros(n_mixtures)),
                                 bounds=log_mixture_mean_bounds)
         self.register_parameter('log_mixture_scales', nn.Parameter(torch.zeros(n_mixtures)),
                                 bounds=log_mixture_scale_bounds)
+
+    def initialize(self, x_train, y, **kwargs):
+        if isinstance(x_train, Variable):
+            x_train = x_train.data
+        if isinstance(y, Variable):
+            y = y.data
+
+        x_train_sort = x_train.sort()[0]
+        max_dis = x_train_sort[-1] - x_train_sort[0]
+        min_dis = torch.min(x_train_sort[1:] - x_train_sort[:-1])
+
+        scales = 1.0 / torch.abs(max_dis * torch.randn(self.n_mixtures))
+        means = (0.5 / min_dis) * torch.rand(self.n_mixtures)
+        weights = torch.ones(self.n_mixtures) * (y.std() / self.n_mixtures)
+
+        self.log_mixture_weights.data = weights.log()
+        self.log_mixture_scales.data = scales.log()
+        self.log_mixture_means.data = means.log()
 
     def forward(self, x1, x2):
         n, d = x1.size()

--- a/test/examples/spectral_mixture_gp_regression_test.py
+++ b/test/examples/spectral_mixture_gp_regression_test.py
@@ -40,6 +40,7 @@ gp_model = SpectralMixtureGPModel()
 
 def test_spectral_mixture_gp_mean_abs_error():
     gp_model = SpectralMixtureGPModel()
+    gp_model.covar_module.initialize(train_x, train_y)
     gp_model.condition(train_x, train_y)
 
     # Optimize the model
@@ -48,7 +49,7 @@ def test_spectral_mixture_gp_mean_abs_error():
     optimizer.n_iter = 0
 
     gpytorch.functions.fastest = False
-    for i in range(50):
+    for i in range(200):
         optimizer.zero_grad()
         output = gp_model(train_x)
         loss = -gp_model.marginal_log_likelihood(output, train_y)


### PR DESCRIPTION
@gpleiss  @jrg365 The simpler initialization has been implemented. This implementation is according to Andrew Wilson's matlab code `initSMhypers.m` https://people.orie.cornell.edu/andrew/code/initSMhypers.m. However, the stability becomes worse in `test/examples/spectral_mixture_gp_regression_test.py`. Also, the implementation of log_mixture_scales in `initSMhypers.m` is not consistent to truncated Gaussian distribution with mean proportional to the max range of the data, which is described in his page https://people.orie.cornell.edu/andrew/code/.

We may consider whether to use this initialization.