### PR TITLE
Remove `explicit_interpolate_T` and `explicit_interpolate_K`

### DIFF
--- a/gpytorch/lazy/toeplitz_lazy_variable.py
+++ b/gpytorch/lazy/toeplitz_lazy_variable.py
@@ -132,33 +132,6 @@ class ToeplitzLazyVariable(LazyVariable):
             res = self.matmul(Variable(torch.eye(len(self.J_right))))
         return res
 
-    def explicit_interpolate_T(self, J, C):
-        """
-        Multiplies the Toeplitz matrix T this object represents (by a column c and row r)
-        by an interpolation matrix W, to get WT, without explicitly forming the Toeplitz
-        matrix T. This is a much more space-efficient approach.
-
-        Args:
-            - J (matrix n-by-k) - Index matrix for interpolation matrix W
-            - C (matrix n-by-k) - Coefficients matrix for interpolation matrix W
-        Returns:
-            - Matrix (n-by-m) - The result of the multiplication WT
-        """
-        m = len(self.c)
-        n, num_coefficients = J.size()
-
-        result_matrix = Variable(torch.zeros(n, m))
-
-        for i in range(n):
-            for j in range(m):
-                entry = 0
-                for k in range(num_coefficients):
-                    row = J[i, k]
-                    entry += C[i, k] * toeplitz.sym_toeplitz_getitem(self.c, row, j)
-                result_matrix[i, j] = entry
-
-        return result_matrix
-
     def monte_carlo_log_likelihood(self, log_probability_func, train_y, variational_mean, chol_var_covar):
         epsilon = Variable(torch.randn(len(self.c), gpytorch.functions.num_trace_samples))
         samples = chol_var_covar.mm(epsilon)

--- a/test/lazy/kronecker_product_lazy_variable_test.py
+++ b/test/lazy/kronecker_product_lazy_variable_test.py
@@ -48,13 +48,6 @@ W_right = list_of_indices_and_values_to_sparse(lazy_kronecker_product_var.J_righ
 WKW = torch.dsmm(W_right, torch.dsmm(W_left, K).t()) + torch.diag(lazy_kronecker_product_var.added_diag.data)
 
 
-def test_explicit_interpolate_K():
-    WK_res = lazy_kronecker_product_var.explicit_interpolate_K(lazy_kronecker_product_var.J_lefts,
-                                                               lazy_kronecker_product_var.C_lefts)
-    WK_actual = torch.dsmm(W_left, K)
-    assert utils.approx_equal(WK_res.data, WK_actual)
-
-
 def test_evaluate():
     WKW_res = lazy_kronecker_product_var.evaluate()
     assert utils.approx_equal(WKW_res, WKW)

--- a/test/lazy/toeplitz_lazy_variable_test.py
+++ b/test/lazy/toeplitz_lazy_variable_test.py
@@ -39,12 +39,6 @@ W_right = utils.toeplitz.index_coef_to_sparse(lazy_toeplitz_var.J_right,
 WTW = torch.dsmm(W_right, torch.dsmm(W_left, T).t()) + torch.diag(lazy_toeplitz_var.added_diag.data)
 
 
-def test_explicit_interpolate_T():
-    WT_res = lazy_toeplitz_var.explicit_interpolate_T(lazy_toeplitz_var.J_left, lazy_toeplitz_var.C_left)
-    WT_actual = torch.dsmm(W_left, T)
-    assert utils.approx_equal(WT_res.data, WT_actual)
-
-
 def test_evaluate():
     WTW_res = lazy_toeplitz_var.evaluate()
     assert utils.approx_equal(WTW_res, WTW)


### PR DESCRIPTION
We no longer use these functions, and they are dangerously slow functions to use.