### PR TITLE
Stochatic trace refactor

### DIFF
--- a/gpytorch/functions/add_diag.py
+++ b/gpytorch/functions/add_diag.py
@@ -8,7 +8,7 @@ class AddDiag(Function):
             raise RuntimeError('Input must be a single-element tensor')
         val = diag.squeeze()[0]
 
-        return torch.eye(*input.size()).mul_(val).add_(input)
+        return torch.eye(*input.size()).type_as(input).mul_(val).add_(input)
 
     def backward(self, grad_output):
         input_grad = None

--- a/gpytorch/kernels/rbf_kernel.py
+++ b/gpytorch/kernels/rbf_kernel.py
@@ -21,7 +21,7 @@ class RBFFunction(Function):
         n, d = tuple(self.x1.size())
         m, _ = tuple(self.x2.size())
 
-        res = torch.zeros(n, m)
+        res = self.x1.new(n, m).zero_()
         res.addmm_(1, 2, self.x1, self.x2.transpose(0, 1))  # res = 2 x1 x2^T
 
         x1_squared = torch.bmm(self.x1.view(n, 1, d), self.x1.view(n, d, 1))

--- a/gpytorch/means/mean.py
+++ b/gpytorch/means/mean.py
@@ -6,7 +6,7 @@ class Mean(gpytorch.Module):
     def initialize(self, **kwargs):
         for param_name, param_value in kwargs.items():
             if hasattr(self, param_name):
-                if isinstance(param_value, torch.Tensor):
+                if torch.is_tensor(param_value):
                     getattr(self, param_name).data.copy_(param_value)
                 else:
                     getattr(self, param_name).data.fill_(param_value)

--- a/gpytorch/utils/__init__.py
+++ b/gpytorch/utils/__init__.py
@@ -4,6 +4,7 @@ from torch.autograd import Variable
 from .interpolation import Interpolation
 from .lincg import LinearCG
 from .lanczos_quadrature import StochasticLQ
+from .trace import trace_components
 
 
 def reverse(input, dim=0):
@@ -170,4 +171,5 @@ __all__ = [
     sparse_eye,
     sparse_getitem,
     sparse_repeat,
+    trace_components,
 ]

--- a/gpytorch/utils/trace.py
+++ b/gpytorch/utils/trace.py
@@ -1,0 +1,134 @@
+import torch
+import gpytorch
+import math
+from torch.autograd import Variable
+
+
+def _identity(x):
+    return x
+
+
+def trace_components(left_matmul_closure, right_matmul_closure, size=None, num_samples=None,
+                     estimator_type='mub', tensor_cls=None, use_vars=False):
+    """
+    Create components for stochastic trace estimation
+    Given two matrices `A` and `B` (represented by closures that define matrix-multiplication
+    operations), returns two matrices `A'` and `B'` such that
+
+    ```
+    trace( A^T B ) = sum(A' * B') (elementwise operation)
+    ```
+
+    If A and B are regular matrices, then this function simply returns A and B,
+    since `trace( A^T B ) = sum(A * B)`
+
+    However, if `A` and `B` are more efficiently represented by matrix multiplication closures
+    (as is the case if A is a  Toeplitz matrices, if A is the inverse of a PSD matrix, etc.)
+    then this will be far more efficient, since `A' and `B'` will have significantly lower dimensionality.
+
+    Args:
+        - left_matmul_closure (Tensor or Variable or function(Tensor) -> Tensor or
+            function(Variable) -> Variable) defines the left matrix, `A` (n x m), or the
+            matrix multiplcation function f(X) = AX
+
+            left_matmul_closure can also be None, which specifies that A is the identity matrix
+
+        - right_matmul_closure (Tensor or Variable or function(Tensor) -> Tensor or
+            function(Variable) -> Variable) defines the right matrix, `B` (n x m), or the
+            matrix multiplcation function f(X) = BX
+
+            right_matmul_closure can also be None, which specifies that B is the identity matrix
+
+        - size (int) -> the number of columns in the matrices `A` and `B` (i.e. m).
+            Only required if left_matmul_closure and right_matmul_closures are not Tensors/Variables
+
+        - num_samples (int) -> the number of random variable samples to stochastically estimate
+            trace. Defaults to `gpytorch.functions.num_trace_samples`
+
+        - estimator_type (str) -> Options are 'mub' (Mutually unbiased bases) or
+            'hutchinson' (Rademacher random variables). (Default 'mub')
+
+        - use_vars (bool) -> If False, then operations are performed on Tensors.
+            If True, then performs operations on Variables. (Default False)
+    """
+    if torch.is_tensor(left_matmul_closure):
+        left_matrix = left_matmul_closure
+        size = left_matrix.size(1)
+        tensor_cls = type(left_matrix)
+        left_matmul_closure = left_matrix.matmul
+
+    if torch.is_tensor(right_matmul_closure):
+        right_matrix = right_matmul_closure
+        size = right_matrix.size(1)
+        tensor_cls = type(right_matrix)
+        right_matmul_closure = right_matrix.matmul
+
+    if left_matmul_closure is None:
+        left_matmul_closure = _identity
+
+    if right_matmul_closure is None:
+        right_matmul_closure = _identity
+
+    if size is None:
+        raise RuntimeError('Size must be specified, since neither left_matmul_closure nor'
+                           ' right_matmul_closure are Tensors/Variables')
+
+    # Default num_samples, tensor_cls
+    if num_samples is None:
+        num_samples = gpytorch.functions.num_trace_samples
+
+    if tensor_cls is None:
+        tensor_cls = torch.Tensor
+
+    # Return A and B if we're using deterministic mode
+    if not gpytorch.functions.fastest or size < num_samples:
+        eye = tensor_cls(size).fill_(1).diag()
+        if use_vars:
+            eye = Variable(eye)
+        return left_matmul_closure(eye), right_matmul_closure(eye)
+
+    # Call appropriate estimator
+    if estimator_type == 'mub':
+        return mubs_trace_components(left_matmul_closure, right_matmul_closure, size, num_samples,
+                                     use_vars=use_vars, tensor_cls=tensor_cls)
+    elif estimator_type == 'hutchinson':
+        return hutchinson_trace_components(left_matmul_closure, right_matmul_closure, size, num_samples,
+                                           use_vars=use_vars, tensor_cls=tensor_cls)
+    else:
+        raise RuntimeError('Unknown estimator_type %s' % estimator_type)
+
+
+def mubs_trace_components(left_matmul_closure, right_matmul_closure, size, num_samples,
+                          tensor_cls=torch.Tensor, use_vars=False):
+    r1_coeff = tensor_cls(size)
+    torch.arange(0, size, out=r1_coeff)
+    r1_coeff.unsqueeze_(1)
+    r2_coeff = ((r1_coeff + 1) * (r1_coeff + 2) / 2)
+
+    r1 = tensor_cls(num_samples).uniform_().mul_(size).floor().type_as(r1_coeff).unsqueeze(1).t()
+    r2 = tensor_cls(num_samples).uniform_().mul_(size).floor().type_as(r1_coeff).unsqueeze(1).t()
+
+    two_pi_n = (2 * math.pi) / size
+    real_comps = torch.cos(two_pi_n * (r1_coeff.matmul(r1) + r2_coeff.matmul(r2))) / math.sqrt(size)
+    imag_comps = torch.sin(two_pi_n * (r1_coeff.matmul(r1) + r2_coeff.matmul(r2))) / math.sqrt(size)
+
+    coeff = math.sqrt(size / num_samples)
+    comps = torch.cat([real_comps, imag_comps], 1).mul_(coeff)
+    if use_vars:
+        comps = Variable(comps)
+
+    left_res = left_matmul_closure(comps)
+    right_res = right_matmul_closure(comps)
+    return left_res, right_res
+
+
+def hutchinson_trace_components(left_matmul_closure, right_matmul_closure, size, num_samples,
+                                tensor_cls=torch.Tensor, use_vars=False):
+    coeff = math.sqrt(1. / num_samples)
+    comps = tensor_cls(size, num_samples).bernoulli_().mul_(2).add_(-1).mul_(coeff)
+    if use_vars:
+        comps = Variable(comps)
+
+    left_res = left_matmul_closure(comps)
+    right_res = right_matmul_closure(comps)
+    return left_res, right_res

--- a/test/util/trace_test.py
+++ b/test/util/trace_test.py
@@ -1,0 +1,44 @@
+import torch
+import math
+from gpytorch.utils import trace_components
+
+
+def test_trace_components_normal_matrices():
+    a_mat = torch.randn(3, 4)
+    b_mat = torch.randn(3, 4)
+
+    a_res, b_res = trace_components(a_mat, b_mat)
+    assert torch.equal(a_res, a_mat)
+    assert torch.equal(b_res, b_mat)
+
+
+def test_trace_components_implicit_matrices_mubs():
+    a_mat = torch.randn(500, 500)
+    b_mat = torch.randn(500, 500)
+
+    # Ensure positive definite
+    a_mat = a_mat.t().matmul(a_mat) + torch.eye(500)
+    b_mat = b_mat.t().matmul(b_mat) + torch.eye(500)
+
+    a_res, b_res = trace_components(a_mat.matmul, b_mat.matmul, size=500,
+                                    num_samples=10)
+
+    actual_trace = (a_mat * b_mat).sum()
+    stochastic_trace = (a_res * b_res).sum()
+    assert math.fabs(actual_trace - stochastic_trace) / actual_trace < 1e-1
+
+
+def test_trace_components_implicit_matrices_hutchinsom():
+    a_mat = torch.randn(500, 500)
+    b_mat = torch.randn(500, 500)
+
+    # Ensure positive definite
+    a_mat = a_mat.t().matmul(a_mat) + torch.eye(500)
+    b_mat = b_mat.t().matmul(b_mat) + torch.eye(500)
+
+    a_res, b_res = trace_components(a_mat.matmul, b_mat.matmul, size=500,
+                                    num_samples=25, estimator_type='hutchinson')
+
+    actual_trace = (a_mat * b_mat).sum()
+    stochastic_trace = (a_res * b_res).sum()
+    assert math.fabs(actual_trace - stochastic_trace) / actual_trace < 1e-1


### PR DESCRIPTION
New util: `gpytorch.utils.trace_components`.

Given a matrix `A^T B` that we want to compute the trace for, this function returns `A'` and `B'` such that `tr(A^T B) = sum(A * B) = sum(A' * B')`.

This function can also be used for efficiently computing the diagonal elements of a matrix, as well as the left and right vectors for derivative quad form (which has been refactored).

@wrh14 @jrg365 