### PR TITLE
initialize_interpolation_grid uses the same grid and inducing points …

### DIFF
--- a/gpytorch/kernels/grid_interpolation_kernel.py
+++ b/gpytorch/kernels/grid_interpolation_kernel.py
@@ -1,3 +1,4 @@
+import math
 import torch
 from torch.autograd import Variable
 from .kernel import Kernel
@@ -9,22 +10,11 @@ class GridInterpolationKernel(Kernel):
     def __init__(self, base_kernel_module):
         super(GridInterpolationKernel, self).__init__()
         self.base_kernel_module = base_kernel_module
-        self.grid = None
-
-    def initialize_interpolation_grid(self, grid_size, grid_bounds):
-        super(GridInterpolationKernel, self).initialize_interpolation_grid(grid_size, grid_bounds)
-        self.grid_size = grid_size
-        self.grid_bounds = grid_bounds
-        self.grid = torch.zeros(len(grid_bounds), grid_size)
-        for i in range(len(grid_bounds)):
-            grid_diff = float(grid_bounds[i][1] - grid_bounds[i][0]) / (grid_size - 2)
-            self.grid[i] = torch.linspace(grid_bounds[i][0] - grid_diff,
-                                          grid_bounds[i][1] + grid_diff,
-                                          grid_size)
-        self.grid = Variable(self.grid)
-        return self
 
     def forward(self, x1, x2, **kwargs):
+        if not self.has_grid:
+            raise RuntimeError('GridInterpolationKernel requires setting the interpolation grid')
+
         n, d = x1.size()
         m, _ = x2.size()
 
@@ -40,14 +30,14 @@ class GridInterpolationKernel(Kernel):
                 both_max = torch.max(x1.max(0)[0].data, x2.max(0)[0].data)[i]
                 if both_min < self.grid_bounds[i][0] or both_max > self.grid_bounds[i][1]:
                     # Out of bounds data is still ok if we are specifically computing kernel values for grid entries.
-                    if torch.abs(both_min - self.grid[i][0].data)[0] > 1e-7:
+                    if math.fabs(both_min - self.grid.data[i][0]) > 1e-7:
                         raise RuntimeError('Received data that was out of bounds for the specified grid. \
                                             Grid bounds were ({}, {}), but min = {}, \
                                             max = {}'.format(self.grid_bounds[i][0],
                                                              self.grid_bounds[i][1],
                                                              both_min,
                                                              both_max))
-                    elif torch.abs(both_max - self.grid[i][-1].data)[0] > 1e-7:
+                    elif math.fabs(both_max - self.grid.data[i][-1]) > 1e-7:
                         raise RuntimeError('Received data that was out of bounds for the specified grid. \
                                             Grid bounds were ({}, {}), but min = {}, \
                                             max = {}'.format(self.grid_bounds[i][0],
@@ -60,24 +50,18 @@ class GridInterpolationKernel(Kernel):
             K_XX = KroneckerProductLazyVariable(k_UUs, Js1, Cs1, Js2, Cs2)
             return K_XX
 
-        if self.grid is None:
-            raise RuntimeError(' '.join([
-                'This GridInterpolationKernel has no grid. Call initialize_interpolation_grid \
-                 on a GPModel first.'
-            ]))
-
         both_min = torch.min(x1.min(0)[0].data, x2.min(0)[0].data)[0]
         both_max = torch.max(x1.max(0)[0].data, x2.max(0)[0].data)[0]
 
         if both_min < self.grid_bounds[0][0] or both_max > self.grid_bounds[0][1]:
             # Out of bounds data is still ok if we are specifically computing kernel values for grid entries.
-            if torch.abs(both_min - self.grid[0][0].data)[0] > 1e-7:
+            if math.fabs(both_min - self.grid.data[0][0]) > 1e-7:
                 raise RuntimeError('Received data that was out of bounds for the specified grid. \
                                     Grid bounds were ({}, {}), but min = {}, max = {}'.format(self.grid_bounds[0][0],
                                                                                               self.grid_bounds[0][1],
                                                                                               both_min,
                                                                                               both_max))
-            elif torch.abs(both_max - self.grid[0][-1].data)[0] > 1e-7:
+            elif math.fabs(both_max - self.grid.data[0][-1]) > 1e-7:
                 raise RuntimeError('Received data that was out of bounds for the specified grid. \
                                     Grid bounds were ({}, {}), but min = {}, max = {}'.format(self.grid_bounds[0][0],
                                                                                               self.grid_bounds[0][1],
@@ -87,7 +71,10 @@ class GridInterpolationKernel(Kernel):
         J2, C2 = Interpolation().interpolate(self.grid.data[0], x2.data.squeeze())
 
         k_UU = self.base_kernel_module(self.grid[0][0], self.grid[0], **kwargs).squeeze()
-
         K_XX = ToeplitzLazyVariable(k_UU, J1, C1, J2, C2)
 
         return K_XX
+
+    @property
+    def needs_grid(self):
+        return True


### PR DESCRIPTION
…for all children

This isn't super necessary - but after struggling to get rid of boundary checks on Interpolation, this is what I pulled out.

It was weird that gp_model and grid_interp_kernel were doing the exact same thing for grids - which seems brittle.