### PR TITLE
Lazy variables and random variables can be cuda/cpu'd

### DIFF
--- a/gpytorch/lazy/kronecker_product_lazy_variable.py
+++ b/gpytorch/lazy/kronecker_product_lazy_variable.py
@@ -12,6 +12,7 @@ from ..utils.kronecker_product import sym_kronecker_product_toeplitz_matmul, kp_
 
 class KroneckerProductLazyVariable(LazyVariable):
     def __init__(self, columns, J_lefts=None, C_lefts=None, J_rights=None, C_rights=None, added_diag=None):
+        super(KroneckerProductLazyVariable, self).__init__(columns, J_lefts, C_lefts, J_rights, C_rights, added_diag)
         if not isinstance(columns, Variable):
             raise RuntimeError('KroneckerProductLazyVariable is intended to wrap Variable versions of \
                                 the first column and row.')

--- a/gpytorch/lazy/mul_lazy_variable.py
+++ b/gpytorch/lazy/mul_lazy_variable.py
@@ -15,6 +15,7 @@ class MulLazyVariable(LazyVariable):
             - max_iter (int) - the maximum iteration in lanczos decomposition in when matmul_mode=approximate
             - num_samples (int) - the samples number when matmul_mode=stochastic
         '''
+        super(MulLazyVariable, self).__init__(*lazy_vars, **kwargs)
         if not all([isinstance(lazy_var, LazyVariable) for lazy_var in lazy_vars]):
             raise RuntimeError('All arguments of a MulLazyVariable should be lazy variables')
 

--- a/gpytorch/lazy/non_lazy_variable.py
+++ b/gpytorch/lazy/non_lazy_variable.py
@@ -12,6 +12,7 @@ class NonLazyVariable(LazyVariable):
         Args:
         - var (Variable: matrix) a variable
         """
+        super(NonLazyVariable, self).__init__(var)
         self.var = var
 
     def _matmul_closure_factory(self, tensor):

--- a/gpytorch/lazy/sum_lazy_variable.py
+++ b/gpytorch/lazy/sum_lazy_variable.py
@@ -4,6 +4,7 @@ from ..posterior import DefaultPosteriorStrategy
 
 class SumLazyVariable(LazyVariable):
     def __init__(self, *lazy_vars):
+        super(SumLazyVariable, self).__init__(*lazy_vars)
         if not all([isinstance(lazy_var, LazyVariable) for lazy_var in lazy_vars]):
             raise RuntimeError('All arguments of a SumLazyVariable should be lazy variables')
 

--- a/gpytorch/lazy/toeplitz_lazy_variable.py
+++ b/gpytorch/lazy/toeplitz_lazy_variable.py
@@ -12,6 +12,7 @@ from ..utils.toeplitz import interpolated_sym_toeplitz_matmul, index_coef_to_spa
 
 class ToeplitzLazyVariable(LazyVariable):
     def __init__(self, c, J_left=None, C_left=None, J_right=None, C_right=None, added_diag=None):
+        super(ToeplitzLazyVariable, self).__init__(c, J_left, C_left, J_right, C_right, added_diag)
         if not isinstance(c, Variable):
             raise RuntimeError('ToeplitzLazyVariable is intended to wrap Variable versions of \
                                 the first column and row.')

--- a/gpytorch/random_variables/bernoulli_random_variable.py
+++ b/gpytorch/random_variables/bernoulli_random_variable.py
@@ -15,6 +15,7 @@ class BernoulliRandomVariable(RandomVariable):
         Params:
         - probability (Variable: scalar or vector n) weights of Bernoulli distribution
         """
+        super(BernoulliRandomVariable, self).__init__(probability)
         if not isinstance(probability, Variable):
             raise RuntimeError('probability should be a Variable')
         if not probability.ndimension() == 1:

--- a/gpytorch/random_variables/categorical_random_variable.py
+++ b/gpytorch/random_variables/categorical_random_variable.py
@@ -16,6 +16,7 @@ class CategoricalRandomVariable(RandomVariable):
         Params:
         - mass_function (Variable: vector k or matrix n x k) weights of categorical distribution
         """
+        super(CategoricalRandomVariable, self).__init__(mass_function)
         if not isinstance(mass_function, Variable):
             raise RuntimeError('mass_function should be a Variable')
 

--- a/gpytorch/random_variables/dirichlet_random_variable.py
+++ b/gpytorch/random_variables/dirichlet_random_variable.py
@@ -16,6 +16,7 @@ class DirichletRandomVariable(RandomVariable):
         Params:
         - alpha (Variable: vector k or matrix n x k) weights of categorical distribution
         """
+        super(DirichletRandomVariable, self).__init__(alpha)
         if not isinstance(alpha, Variable):
             raise RuntimeError('alpha should be a Variable')
 

--- a/gpytorch/random_variables/gaussian_random_variable.py
+++ b/gpytorch/random_variables/gaussian_random_variable.py
@@ -16,6 +16,7 @@ class GaussianRandomVariable(RandomVariable):
         - mean (Variable: vector n or matrix b x n) mean of Gaussian distribution
         - covar (Variable: matrix n x n or batch matrix b x n x n) covariance of Gaussian distribution
         """
+        super(GaussianRandomVariable, self).__init__(mean, covar)
         if not isinstance(mean, Variable) and not isinstance(mean, LazyVariable):
             raise RuntimeError('The mean of a GaussianRandomVariable must be a Variable')
 

--- a/gpytorch/random_variables/mixture_random_variable.py
+++ b/gpytorch/random_variables/mixture_random_variable.py
@@ -5,7 +5,7 @@ from torch.autograd import Variable
 
 
 class MixtureRandomVariable(RandomVariable):
-    def __init__(self, rand_vars, weights=None):
+    def __init__(self, *rand_vars, **kwargs):
         """
         Mixture of random variables
 
@@ -15,9 +15,11 @@ class MixtureRandomVariable(RandomVariable):
 
         Note that weights must sum to 1
         """
+        super(MixtureRandomVariable, self).__init__(*rand_vars, **kwargs)
         if not all(isinstance(rand_var, RandomVariable) for rand_var in rand_vars):
             raise RuntimeError('Everything needs to be an instance of a random variable')
 
+        weights = kwargs.get('weights', None)
         if weights is None:
             weights = rand_vars[0].representation()[0].data.new(len(rand_vars)).fill_(1. / len(rand_vars))
 

--- a/gpytorch/random_variables/samples_random_variable.py
+++ b/gpytorch/random_variables/samples_random_variable.py
@@ -13,6 +13,7 @@ class SamplesRandomVariable(RandomVariable):
         Params:
         - samples (Variable: b x ...) samples
         """
+        super(SamplesRandomVariable, self).__init__(samples)
         if not isinstance(samples, Variable):
             raise RuntimeError('samples should be a Variable')
         self._samples = samples


### PR DESCRIPTION
Lazy variables and random variables must now call `super(<Class>, self).__init__(*args, **kwargs)`, but this allows us easily to construct cpu and cuda versions of these objects, using the same interface as for Variables and Tensors.