### PR TITLE
Remove variational strategy checks from gaussian_random_variable (Fix for #58)

### DIFF
--- a/gpytorch/random_variables/gaussian_random_variable.py
+++ b/gpytorch/random_variables/gaussian_random_variable.py
@@ -53,18 +53,8 @@ class GaussianRandomVariable(RandomVariable):
         return self._mean.size(0)
 
     def __add__(self, other):
-        from ..variational import SumVariationalStrategy
         if isinstance(other, GaussianRandomVariable):
-            res = GaussianRandomVariable(self._mean + other.mean(), self._covar + other.covar())
-            if hasattr(self, '_variational_strategy') and hasattr(other, '_variational_strategy'):
-                if isinstance(self._variational_strategy, SumVariationalStrategy):
-                    var_strat = SumVariationalStrategy(*(list(self._variational_strategy.variational_strategies) +
-                                                         [other._variational_strategy]))
-                    res._variational_strategy = var_strat
-                else:
-                    res._variational_strategy = SumVariationalStrategy(self._variational_strategy,
-                                                                       other._variational_strategy)
-            return res
+            return GaussianRandomVariable(self._mean + other.mean(), self._covar + other.covar())
         elif isinstance(other, int) or isinstance(other, float):
             return GaussianRandomVariable(self._mean + other, self._covar)
         else:


### PR DESCRIPTION
Removes some seemingly old checks in `gaussian_random_variable.py` for variational strategies -- I think this is holdover code from before one of the recent refactors. I don't think `RandomVariables` have variational strategies now.

#58 

@gpleiss 